### PR TITLE
fix the movie repeat issue

### DIFF
--- a/src/utils/useGetMovies.js
+++ b/src/utils/useGetMovies.js
@@ -1,29 +1,26 @@
-import axios from "axios";
-import { useEffect, useState } from "react";
-import { nowPlayingUrl } from "./constants";
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { nowPlayingUrl } from './constants';
 
-export const options = {
-  params: { language: "en-US", page: "1" },
+export const defaultOptions = {
+  params: { language: 'en-US', page: '1' },
   headers: {
-    accept: "application/json",
+    accept: 'application/json',
     Authorization:
-      "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI4MjU4NjY4OTNjNjBiYTVjYmYwZTY3MThiZGQ2NzMxMCIsInN1YiI6IjY1Y2JiYTFjOGM0NGI5MDE4MDk0MTc5MyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.pRwXeZxUfIkxE78P1llG_i4SlD3CV6i8dfhHeU9Y1EI",
-  },
+      'Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI4MjU4NjY4OTNjNjBiYTVjYmYwZTY3MThiZGQ2NzMxMCIsInN1YiI6IjY1Y2JiYTFjOGM0NGI5MDE4MDk0MTc5MyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.pRwXeZxUfIkxE78P1llG_i4SlD3CV6i8dfhHeU9Y1EI'
+  }
 };
 
-function useFetch(url = nowPlayingUrl, method = "GET") {
+function useFetch(url = nowPlayingUrl, method = 'GET') {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  options.method = method;
-  options.url = url;
-
-  console.log(url);
-
   useEffect(() => {
+    const fetchOptions = { ...defaultOptions, method, url };
+
     axios
-      .request(options)
+      .request(fetchOptions)
       .then((response) => {
         setData(response?.data?.results);
       })
@@ -31,7 +28,7 @@ function useFetch(url = nowPlayingUrl, method = "GET") {
         setError(error);
       })
       .finally(() => setLoading(false));
-  }, [url]);
+  }, [url, method]);
 
   return [data, loading, error];
 }


### PR DESCRIPTION
options object used in the axios.request call inside the useFetch hook is being mutated each time the hook is called. Since JavaScript objects are reference types, any changes to the options object will persist across different instances of the useFetch hook, causing unintended side effects.

To fix this, you should avoid mutating the options object directly inside the useFetch hook. Instead, create a new options object for each request to ensure that each call to useFetch has its own separate configuration